### PR TITLE
Add support for split APKs

### DIFF
--- a/app/src/main/kotlin/gplay/downloader/App.kt
+++ b/app/src/main/kotlin/gplay/downloader/App.kt
@@ -3,6 +3,7 @@ package gplay.downloader
 import java.io.File
 import java.io.FileNotFoundException
 import java.io.InputStream
+import net.sourceforge.argparse4j.impl.Arguments
 import net.sourceforge.argparse4j.ArgumentParsers
 import net.sourceforge.argparse4j.inf.ArgumentParserException
 
@@ -23,30 +24,36 @@ fun main(args: Array<String>) {
     // Create argument parser
     val argParser = ArgumentParsers.newArgumentParser("gplay-downloader")
     argParser
-            .addArgument("-a")
+            .addArgument("-a", "--app-ids")
             .dest("appids_path")
             .required(true)
             .help("path to the file containing app ids")
     argParser
-            .addArgument("-c")
+            .addArgument("-c", "--auth-config")
             .dest("authconfig_path")
             .required(true)
             .help("path to the auth config file")
     argParser
-            .addArgument("-o")
+            .addArgument("-o", "--output")
             .dest("output_path")
             .required(true)
             .help("the path where the apps will be downloaded to")
     argParser
-            .addArgument("-p")
+            .addArgument("-p", "--proxy-config")
             .dest("proxyconfig_path")
             .required(false)
             .help("path to the proxy config file (optional)")
+    argParser
+            .addArgument("-s", "--single-apk")
+            .action(Arguments.storeTrue())
+            .required(false)
+            .help("download only the main APK file")
 
     var appIdsPath: String = ""
     var authConfigPath: String = ""
     var outputPath: String = ""
     var proxyConfigPath: String? = null
+    var singleApk: Boolean = false
 
     // Try to assign values to variables from parsed arguments
     try {
@@ -55,6 +62,7 @@ fun main(args: Array<String>) {
         authConfigPath = namespace.getString("authconfig_path")
         outputPath = namespace.getString("output_path")
         proxyConfigPath = namespace.getString("proxyconfig_path")
+        singleApk = namespace.getBoolean("single_apk")
     } catch (e: ArgumentParserException) {
         argParser.handleError(e)
         System.exit(2)
@@ -92,7 +100,7 @@ fun main(args: Array<String>) {
     log.status("Initialized config manager")
 
     // Download each app
-    val downloader = Downloader(log, outputPath, configManager)
+    val downloader = Downloader(log, outputPath, configManager, singleApk)
     downloader.downloadAll(appIds)
 
     log.status("=====Finished=====")

--- a/app/src/main/kotlin/gplay/downloader/App.kt
+++ b/app/src/main/kotlin/gplay/downloader/App.kt
@@ -47,7 +47,7 @@ fun main(args: Array<String>) {
             .addArgument("-s", "--single-apk")
             .action(Arguments.storeTrue())
             .required(false)
-            .help("download only the main APK file")
+            .help("download only the main APK file if set (optional)")
 
     var appIdsPath: String = ""
     var authConfigPath: String = ""

--- a/app/src/main/kotlin/gplay/downloader/Downloader.kt
+++ b/app/src/main/kotlin/gplay/downloader/Downloader.kt
@@ -47,10 +47,19 @@ class Downloader(
         return Query(files, true)
     }
 
-    private fun downloadQuery(query: Query) {
+    private fun downloadQuery(query: Query, appId: String) {
+        var outputDir = outputPath
+
+        // Group all APKs of the same app into a directory if the 'single APK' option was not set
+        // This step is necessary because many of the split APKs share the same names
+        if (!singleApk) {
+            outputDir += "$appId/"
+            File(outputDir).mkdirs()
+        }
+
         for (file in query.files) {
-            val path = outputPath + file.name
-            URL(file.url).openStream().use { Files.copy(it, Paths.get(path)) }
+            val outputFile = outputDir + file.name
+            URL(file.url).openStream().use { Files.copy(it, Paths.get(outputFile)) }
         }
     }
 
@@ -99,7 +108,7 @@ class Downloader(
                 log.warning("NOTFOUND AppId $id")
             } else {
                 try {
-                    downloadQuery(query)
+                    downloadQuery(query, id)
                     log.success("Downloaded AppId $id")
                 } catch (e: Exception) {
                     log.error("DownloadError: Could not download AppId $id")


### PR DESCRIPTION
- Added support for split APKs. All files of the apps get downloaded by default. 
- Added an option, `-s` or `--single-apk`, for downloading only the main binary of the split APKs.
- All command line flags now also have long names. Please refer to the help message to see all of them using the command `java -jar <jar file> --help`.

Solves #2 